### PR TITLE
Force evaluation of iterator so that all joints are unloaded.

### DIFF
--- a/animation/AnimationStructure.py
+++ b/animation/AnimationStructure.py
@@ -44,7 +44,7 @@ def load_from_maya(root):
             not any(pm.listRelatives(c, s=True)) and 
             (any(pm.listRelatives(c, ad=True, ap=False, type='joint')) or isinstance(c, pm.nt.Joint))]
         
-        map(lambda c: unload_joint(c, parents, id), children)
+        list(map(lambda c: unload_joint(c, parents, id), children))
 
     unload_joint(root, parents, -1)
     


### PR DESCRIPTION
When loading an animation from Maya, only the first bone is loaded.
The recursion doesn't happen because map is a lazy iterator in Python3. 
I force the evaluation by constructing a list. This should work in both Python2 and Python3.